### PR TITLE
Only initialize sentry in release builds

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ fn main() {
 
     init_flags();
     // initialize sentry and custom panic handler for msgbox
+    #[cfg(not(debug_assertions))]
     let _guard = sentry::init((beans_rs::SENTRY_URL, sentry::ClientOptions {
         release: sentry::release_name!(),
         debug: flags::has_flag(LaunchFlag::DEBUG_MODE),


### PR DESCRIPTION
No need to log any errors during development, right?