### PR TITLE
Change Sentry DSN

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod logger;
 /// NOTE do not change, fetches from the version of beans-rs on build
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// sentry url, change on fork please.
-pub const SENTRY_URL: &str = "https://e6e260fa3408f2cf934b4b3c4be71c74@sentry.kate.pet/2";
+pub const SENTRY_URL: &str = "https://9df80170f0a4411bb9c834ac54734380@sentry.kate.pet/1";
 /// content to display when showing a message box on panic.
 pub const PANIC_MSG_CONTENT: &str = include_str!("text/msgbox_panic_text.txt");
 /// once everything is done, do we wait for the user to press enter before exiting?


### PR DESCRIPTION
This PR Changes the Sentry DSN URL Since I've switched to GlitchTip instead of self-hosted Sentry so less resources are used on my home server.