### PR TITLE
Custom Temporary Directory

### DIFF
--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -399,7 +399,9 @@ pub const CUSTOM_TMPDIR_NAME: &str = "ADASTRAL_TMPDIR";
 pub fn get_tmp_dir() -> String
 {
     let mut dir = std::env::temp_dir().to_str().unwrap_or("").to_string();
-    if is_steamdeck() {
+    if let Some(x) = use_custom_tmpdir() {
+        dir = x;
+    } else if is_steamdeck() {
         trace!("[helper::get_tmp_dir] Detected that we are running on a steam deck. Using ~/.tmp/beans-rs");
         match simple_home_dir::home_dir() {
             Some(v) => {

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -376,6 +376,25 @@ pub fn format_size(i: usize) -> String {
     }
     return format!("{}{}", whole, dec_x);
 }
+/// Check if we should use the custom temporary directory, which is stored in the environment variable
+/// defined in `CUSTOM_TMPDIR_NAME`.
+/// 
+/// ## Return
+/// `Some` when the environment variable is set, and the directory exist. 
+/// Otherwise `None` is returned.
+pub fn use_custom_tmpdir() -> Option<String>
+{
+    if let Ok(x) = std::env::var(CUSTOM_TMPDIR_NAME) {
+        let s = x.to_string();
+        if dir_exists(s.clone()) {
+            return Some(s);
+        } else {
+            warn!("[use_custom_tmp_dir] Custom temporary directory \"{}\" doesn't exist", s);
+        }
+    }
+    return None;
+}
+pub const CUSTOM_TMPDIR_NAME: &str = "ADASTRAL_TMPDIR";
 /// Create directory in temp directory with name of "beans-rs"
 pub fn get_tmp_dir() -> String
 {


### PR DESCRIPTION
Add the ability to have a custom temporary directory, which can be defined in the environment variable `ADASTRAL_TMPDIR`.

## Note
The temporary directory must exist for beans to actually use it.