### PR TITLE
Show Current and Latest Version when an Update is available.

### DIFF
--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -100,8 +100,10 @@ impl WizardContext
                 if cv < rv
                 {
                     println!(
-                        "======== A new update for {} is available! (v{rv}) ========",
-                        av.mod_info.name_stylized
+                        "======== A new update for {} is available! (latest: v{}, current: v{}) ========",
+                        av.mod_info.name_stylized,
+                        rv,
+                        cv
                     );
                 }
             }


### PR DESCRIPTION
When using the Wizard, and a new update is available, this PR will change the message that is printed so it shows you what the latest version is, and what the current version is, instead of just showing you the latest version.