### PR TITLE
Progress Bar for file extraction

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -281,13 +281,16 @@ impl RunnerContext
     {
         let tar_tmp_location = helper::get_tmp_file("data.tar".to_string());
 
-        let zstd_file = std::fs::File::open(&zstd_location)?;
-        let mut tar_tmp_file = std::fs::File::create_new(&tar_tmp_location)?;
-        zstd::stream::copy_decode(zstd_file, &tar_tmp_file)?;
-        tar_tmp_file = std::fs::File::open(&tar_tmp_location)?; // we do this again to make sure that the tar is properly opened.
-
-        let mut archive = tar::Archive::new(&tar_tmp_file);
-        let x = archive.unpack(&out_dir);
+        if let Err(e) = crate::extract::decompress_zstd(zstd_location.clone(), tar_tmp_location.clone(), true) {
+            debug!("{:#?}", e);
+            error!("[RunnerContext::extract_package] Failed to decompress file {} ({:})", zstd_location, e);
+            return Err(e);
+        }
+        if let Err(e) = crate::extract::unpack_tarball(tar_tmp_location.clone(), out_dir, true) {
+            debug!("{:#?}", e);
+            error!("[RunnerContext::extract_package] Failed to unpack tarball {} ({:})", tar_tmp_location, e);
+            return Err(e);
+        }
         if helper::file_exists(tar_tmp_location.clone())
         {
             if let Err(e) = std::fs::remove_file(tar_tmp_location.clone())
@@ -303,22 +306,7 @@ impl RunnerContext
                 );
             }
         }
-        match x
-        {
-            Err(e) =>
-            {
-                let xe = BeansError::TarExtractFailure {
-                    src_file: tar_tmp_location,
-                    target_dir: out_dir,
-                    error: e,
-                    backtrace: Backtrace::capture()
-                };
-                trace!("[RunnerContext::extract_package] {:}\n{:#?}", xe, xe);
-                sentry::capture_error(&xe);
-                Err(xe)
-            }
-            Ok(_) => Ok(())
-        }
+        Ok(())
     }
 
     #[cfg(target_os = "linux")]

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -281,14 +281,23 @@ impl RunnerContext
     {
         let tar_tmp_location = helper::get_tmp_file("data.tar".to_string());
 
-        if let Err(e) = crate::extract::decompress_zstd(zstd_location.clone(), tar_tmp_location.clone(), true) {
+        if let Err(e) =
+            crate::extract::decompress_zstd(zstd_location.clone(), tar_tmp_location.clone(), true)
+        {
             debug!("{:#?}", e);
-            error!("[RunnerContext::extract_package] Failed to decompress file {} ({:})", zstd_location, e);
+            error!(
+                "[RunnerContext::extract_package] Failed to decompress file {} ({:})",
+                zstd_location, e
+            );
             return Err(e);
         }
-        if let Err(e) = crate::extract::unpack_tarball(tar_tmp_location.clone(), out_dir, true) {
+        if let Err(e) = crate::extract::unpack_tarball(tar_tmp_location.clone(), out_dir, true)
+        {
             debug!("{:#?}", e);
-            error!("[RunnerContext::extract_package] Failed to unpack tarball {} ({:})", tar_tmp_location, e);
+            error!(
+                "[RunnerContext::extract_package] Failed to unpack tarball {} ({:})",
+                tar_tmp_location, e
+            );
             return Err(e);
         }
         if helper::file_exists(tar_tmp_location.clone())

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,15 @@ pub enum BeansError
         error: std::io::Error,
         backtrace: Backtrace
     },
+    #[error("Failed to extract item {link_name} to directory {target_dir} ({error:})")]
+    TarUnpackItemFailure
+    {
+        src_file: String,
+        target_dir: String,
+        link_name: String,
+        error: std::io::Error,
+        backtrace: Backtrace
+    },
     #[error("Failed to send request ({error:})")]
     Reqwest
     {

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,0 +1,124 @@
+use log::info;
+use std::{backtrace::Backtrace, fs::File, io::Read};
+use indicatif::{ProgressBar, ProgressStyle};
+use zstd::stream::read::Decoder as ZstdDecoder;
+
+use crate::BeansError;
+
+pub fn unpack_tarball(tarball_location: String, output_directory: String, show_progress: bool) -> Result<(), BeansError>
+{
+    let tarball = match File::open(&tarball_location) {
+        Ok(x) => x,
+        Err(e) => {
+            return Err(BeansError::TarExtractFailure {
+                src_file: tarball_location,
+                target_dir: output_directory,
+                error: e,
+                backtrace: Backtrace::capture()
+            });
+        }
+    };
+    let mut archive = tar::Archive::new(&tarball);
+    if show_progress {
+        let archive_entries = match archive.entries()
+        {
+            Ok(v) => v,
+            Err(e) =>
+            {
+                return Err(BeansError::TarExtractFailure {
+                    src_file: tarball_location,
+                    target_dir: output_directory,
+                    error: e,
+                    backtrace: Backtrace::capture()
+                });
+            }
+        };
+        let archive_entry_count = (&archive_entries.count()).clone() as u64;
+        info!("Extracting {} files", archive_entry_count);
+    
+        let pb = ProgressBar::new(archive_entry_count);
+        pb.set_style(ProgressStyle::with_template("{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} ({eta})")
+            .unwrap()
+            .with_key("eta", |state: &indicatif::ProgressState, w: &mut dyn std::fmt::Write| write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap())
+            .progress_chars("#>-"));
+        pb.set_message("Extracting files");
+    
+        archive = tar::Archive::new(&tarball);
+        match archive.entries() {
+            Ok(etrs) =>
+            {
+                for entry in etrs {
+                    match entry {
+                        Ok(mut x) => {
+                            let ln = x.link_name();
+                            pb.set_message("Extracting files");
+                            let mut filename = String::new();
+                            if let Ok(n) = ln {
+                                if let Some(p) = n {
+                                    if let Some(s) = p.to_str() {
+                                        pb.set_message(format!("{:}", s));
+                                        filename = String::from(s);
+                                    }
+                                }
+                            }
+                            if let Err(e) = x.unpack_in(&output_directory) {
+                                return Err(BeansError::TarUnpackItemFailure {
+                                    src_file: tarball_location,
+                                    target_dir: output_directory,
+                                    link_name: filename,
+                                    error: e,
+                                    backtrace: Backtrace::capture()
+                                });
+                            }
+                            pb.inc(1);
+                        },
+                        Err(e) => {
+                            return Err(BeansError::TarExtractFailure {
+                                src_file: tarball_location,
+                                target_dir: output_directory,
+                                error: e,
+                                backtrace: Backtrace::capture()
+                            });
+                        }
+                    };
+                }
+            },
+            Err(e) =>
+            {
+                return Err(BeansError::TarExtractFailure {
+                    src_file: tarball_location,
+                    target_dir: output_directory,
+                    error: e,
+                    backtrace: Backtrace::capture()
+                });
+            }
+        };
+        pb.finish();
+    } else {
+        archive.unpack(output_directory);
+    }
+    return Ok(());
+}
+pub fn decompress_zstd(zstd_location: String, output_file: String, show_progress: bool) -> Result<(), BeansError>
+{
+    let zstd_file = File::open(&zstd_location)?;
+    let zstd_file_length = &zstd_file.metadata()?.len();
+    let mut tar_tmp_file = File::create_new(&output_file)?;
+    if show_progress {
+        let decoder = ZstdDecoder::new(zstd_file)?;
+        // estimate extracted size as x2 since idk how to get the decompressed size with zstd
+        let pb_decompress = ProgressBar::new((zstd_file_length.clone() * 2) as u64);
+        pb_decompress
+            .set_style(ProgressStyle::with_template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})")
+            .unwrap()
+            .with_key("eta", |state: &indicatif::ProgressState, w: &mut dyn std::fmt::Write| write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap())
+            .progress_chars("#>-"));
+        
+        std::io::copy(&mut pb_decompress.wrap_read(decoder), &mut tar_tmp_file).expect("Failed to decompress file");
+        pb_decompress.finish();
+    } else {
+        zstd::stream::copy_decode(zstd_file, &tar_tmp_file)?;
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,10 +22,10 @@ pub use error::*;
 
 pub mod appvar;
 pub mod butler;
+pub mod extract;
 pub mod flags;
 pub mod gui;
 pub mod logger;
-pub mod extract;
 
 /// NOTE do not change, fetches from the version of beans-rs on build
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -60,33 +60,36 @@ pub fn data_dir() -> String
 
 /// Temporary directory which is specified by `ADASTRAL_TMPDIR`.
 ///
-/// Will return `None` when the environment variable couldn't be found, or it's an empty string.
+/// Will return `None` when the environment variable couldn't be found, or it's
+/// an empty string.
 pub fn env_custom_tmpdir() -> Option<String>
 {
     let s = helper::try_get_env_var(String::from("ADASTRAL_TMPDIR"));
-    match s {
-        Some(x) => match x.trim().is_empty() {
+    match s
+    {
+        Some(x) => match x.trim().is_empty()
+        {
             true => None,
             false => Some(x)
         },
         None => s
     }
 }
-/// Return `true` when the environment variable `BEANS_DEBUG` or `ADASTRAL_DEBUG` exists and
-/// equals `1` or `true`.
+/// Return `true` when the environment variable `BEANS_DEBUG` or
+/// `ADASTRAL_DEBUG` exists and equals `1` or `true`.
 pub fn env_debug() -> bool
 {
     check_env_bool("BEANS_DEBUG") || check_env_bool("ADASTRAL_DEBUG")
 }
-/// Return `true` when the environment variable `BEANS_HEADLESS` or `ADASTRAL_HEADLESS` exists and
-/// equals `1` or `true`.
+/// Return `true` when the environment variable `BEANS_HEADLESS` or
+/// `ADASTRAL_HEADLESS` exists and equals `1` or `true`.
 pub fn env_headless() -> bool
 {
     check_env_bool("BEANS_HEADLESS") || check_env_bool("ADASTRAL_HEADLESS")
 }
 
-/// Return `true` when the environment variable exists, and it's value equals `1` or `true (when
-/// trimmed and made lowercase).
+/// Return `true` when the environment variable exists, and it's value equals
+/// `1` or `true (when trimmed and made lowercase).
 fn check_env_bool<K: AsRef<std::ffi::OsStr>>(key: K) -> bool
 {
     std::env::var(key).is_ok_and(|x| {
@@ -112,7 +115,8 @@ pub fn has_gui_support() -> bool
         }
     }
 
-    if env_headless() {
+    if env_headless()
+    {
         return true;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod butler;
 pub mod flags;
 pub mod gui;
 pub mod logger;
+pub mod extract;
 
 /// NOTE do not change, fetches from the version of beans-rs on build
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
Just like the title says, a progress bar is added for `.tar.zstd` extraction. New module was made for this, and used in `RunnerContext::extract_package`

Currently unknown how to get the decompressed size of a zstd file, so the file size x2 is used for the max value in the progress bar.