### PR TITLE
Add aria2c support

### DIFF
--- a/src/appvar.rs
+++ b/src/appvar.rs
@@ -128,7 +128,9 @@ impl AppVarData
                 if let Ok(mut ms) = JSON_DATA.write()
                 {
                     *ms = v.to_string();
-                    debug!("[AppVarData::set_json_data] successfully set data, calling reset_appvar()");
+                    debug!(
+                        "[AppVarData::set_json_data] successfully set data, calling reset_appvar()"
+                    );
                 }
                 Self::reset();
                 Ok(())

--- a/src/aria2.rs
+++ b/src/aria2.rs
@@ -1,20 +1,32 @@
 use std::process::ExitStatus;
-use crate::{depends, helper, BeansError, DownloadFailureReason};
-use log::{info, debug, error};
+
+use log::{debug,
+          error,
+          info};
+
+use crate::{depends,
+            helper,
+            BeansError,
+            DownloadFailureReason};
 
 pub fn can_use_aria2() -> bool
 {
     get_executable_location().is_some()
 }
-pub fn get_executable_location() -> Option<String> {
-    if let Some(r) = helper::get_program_env_location(String::from("aria2c")) {
+pub fn get_executable_location() -> Option<String>
+{
+    if let Some(r) = helper::get_program_env_location(String::from("aria2c"))
+    {
         return Some(r);
     }
-    if let Some(r) = helper::get_program_env_location(String::from("aria2c.exe")) {
+    if let Some(r) = helper::get_program_env_location(String::from("aria2c.exe"))
+    {
         return Some(r);
     }
-    if let Some(x) = depends::get_aria2c_location() {
-        if helper::file_exists(x.clone()) {
+    if let Some(x) = depends::get_aria2c_location()
+    {
+        if helper::file_exists(x.clone())
+        {
             return Some(x);
         }
     }
@@ -22,11 +34,16 @@ pub fn get_executable_location() -> Option<String> {
     None
 }
 
-pub async fn download_file(url: String, out_location: String) -> Result<ExitStatus, BeansError>
+pub async fn download_file(
+    url: String,
+    out_location: String
+) -> Result<ExitStatus, BeansError>
 {
-    let exe_location = match get_executable_location() {
+    let exe_location = match get_executable_location()
+    {
         Some(x) => x,
-        None => {
+        None =>
+        {
             return Err(BeansError::DownloadFailure {
                 reason: DownloadFailureReason::MissingAria2cExecutable,
                 backtrace: std::backtrace::Backtrace::capture()
@@ -37,8 +54,14 @@ pub async fn download_file(url: String, out_location: String) -> Result<ExitStat
     info!("[aria2::download_file] URL: {}", url);
     let output_directory = helper::remove_path_head(out_location.clone());
     let output_filename = helper::get_filename(out_location.clone());
-    debug!("[aria2::download_file] output_directory: {}", output_directory);
-    debug!("[aria2::download_file] output_filename: {}", output_filename);
+    debug!(
+        "[aria2::download_file] output_directory: {}",
+        output_directory
+    );
+    debug!(
+        "[aria2::download_file] output_filename: {}",
+        output_filename
+    );
     cmd.args([
         "-d",
         &output_directory,
@@ -49,8 +72,10 @@ pub async fn download_file(url: String, out_location: String) -> Result<ExitStat
     ]);
     debug!("[aria2::download_file] spawn\n{:#?}", cmd);
     let cmd_string = format!("{:#?}", cmd);
-    match cmd.spawn() {
-        Err(e) => {
+    match cmd.spawn()
+    {
+        Err(e) =>
+        {
             debug!("[aria2::download_file] failed to spawn process: {:#?}", e);
             error!("[aria2::download_file] Failed to spawn process ({e:})");
             Err(BeansError::DownloadFailure {
@@ -61,12 +86,15 @@ pub async fn download_file(url: String, out_location: String) -> Result<ExitStat
                 },
                 backtrace: std::backtrace::Backtrace::capture()
             })
-        },
-        Ok(mut child) => {
+        }
+        Ok(mut child) =>
+        {
             let wait_status = child.wait()?;
             debug!("[aria2::download_file] exited status {:#?}", wait_status);
-            if let Some(code) = wait_status.code() {
-                if let Some(error_code) = crate::error::Aria2cExitCodeReason::from_exit_code(code) {
+            if let Some(code) = wait_status.code()
+            {
+                if let Some(error_code) = crate::error::Aria2cExitCodeReason::from_exit_code(code)
+                {
                     return Err(BeansError::Aria2cExitCode {
                         reason: error_code,
                         cmd: cmd_string,

--- a/src/aria2.rs
+++ b/src/aria2.rs
@@ -24,11 +24,9 @@ pub fn get_executable_location() -> Option<String>
         return Some(r);
     }
     if let Some(x) = depends::get_aria2c_location()
+        && helper::file_exists(x.clone())
     {
-        if helper::file_exists(x.clone())
-        {
-            return Some(x);
-        }
+        return Some(x);
     }
 
     None

--- a/src/aria2.rs
+++ b/src/aria2.rs
@@ -1,0 +1,80 @@
+use std::process::ExitStatus;
+use crate::{depends, helper, BeansError, DownloadFailureReason};
+use log::{info, debug, error};
+
+pub fn can_use_aria2() -> bool
+{
+    get_executable_location().is_some()
+}
+pub fn get_executable_location() -> Option<String> {
+    if let Some(r) = helper::get_program_env_location(String::from("aria2c")) {
+        return Some(r);
+    }
+    if let Some(r) = helper::get_program_env_location(String::from("aria2c.exe")) {
+        return Some(r);
+    }
+    if let Some(x) = depends::get_aria2c_location() {
+        if helper::file_exists(x.clone()) {
+            return Some(x);
+        }
+    }
+
+    None
+}
+
+pub async fn download_file(url: String, out_location: String) -> Result<ExitStatus, BeansError>
+{
+    let exe_location = match get_executable_location() {
+        Some(x) => x,
+        None => {
+            return Err(BeansError::DownloadFailure {
+                reason: DownloadFailureReason::MissingAria2cExecutable,
+                backtrace: std::backtrace::Backtrace::capture()
+            });
+        }
+    };
+    let mut cmd = std::process::Command::new(exe_location);
+    info!("[aria2::download_file] URL: {}", url);
+    let output_directory = helper::remove_path_head(out_location.clone());
+    let output_filename = helper::get_filename(out_location.clone());
+    debug!("[aria2::download_file] output_directory: {}", output_directory);
+    debug!("[aria2::download_file] output_filename: {}", output_filename);
+    cmd.args([
+        "-d",
+        &output_directory,
+        format!("--out={}", output_filename).as_str(),
+        "-c",
+        format!("--user-agent={}", crate::get_user_agent()).as_str(),
+        &url
+    ]);
+    debug!("[aria2::download_file] spawn\n{:#?}", cmd);
+    let cmd_string = format!("{:#?}", cmd);
+    match cmd.spawn() {
+        Err(e) => {
+            debug!("[aria2::download_file] failed to spawn process: {:#?}", e);
+            error!("[aria2::download_file] Failed to spawn process ({e:})");
+            Err(BeansError::DownloadFailure {
+                reason: DownloadFailureReason::Aria2cSpawnError {
+                    url,
+                    output_file: out_location,
+                    error: e
+                },
+                backtrace: std::backtrace::Backtrace::capture()
+            })
+        },
+        Ok(mut child) => {
+            let wait_status = child.wait()?;
+            debug!("[aria2::download_file] exited status {:#?}", wait_status);
+            if let Some(code) = wait_status.code() {
+                if let Some(error_code) = crate::error::Aria2cExitCodeReason::from_exit_code(code) {
+                    return Err(BeansError::Aria2cExitCode {
+                        reason: error_code,
+                        cmd: cmd_string,
+                        backtrace: std::backtrace::Backtrace::capture()
+                    });
+                }
+            }
+            Ok(wait_status)
+        }
+    }
+}

--- a/src/butler.rs
+++ b/src/butler.rs
@@ -69,7 +69,8 @@ pub async fn patch_dl(
         return Err(BeansError::DownloadFailure {
             reason: DownloadFailureReason::FileNotFound {
                 location: tmp_file
-            }
+            },
+            backtrace: std::backtrace::Backtrace::capture()
         });
     }
 

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -242,7 +242,7 @@ impl RunnerContext
 
     /// Download package with Progress Bar.
     /// Ok is the location to where it was downloaded to.
-    pub async fn download_package(version: RemoteVersion) -> Result<String, BeansError>
+    pub async fn download_package(version: RemoteVersion, version_id: usize) -> Result<String, BeansError>
     {
         let av = AppVarData::get();
         let mut out_loc = helper::get_tmp_dir();

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -256,7 +256,7 @@ impl RunnerContext
         }
 
         let out_filename = match crate::aria2::can_use_aria2() {
-            true => format!("{}_{}.dl", av.mod_info.sourcemod_name, version_id),
+            true => format!("{}_{}.pkg", av.mod_info.sourcemod_name, version_id),
             false => format!("presz_{}", helper::generate_rand_str(12))
         };
         out_loc = helper::join_path(out_loc, out_filename);

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -255,7 +255,10 @@ impl RunnerContext
             }
         }
 
-        let out_filename = format!("presz_{}", helper::generate_rand_str(12));
+        let out_filename = match crate::aria2::can_use_aria2() {
+            true => format!("{}_{}.dl", av.mod_info.sourcemod_name, version_id),
+            false => format!("presz_{}", helper::generate_rand_str(12))
+        };
         out_loc = helper::join_path(out_loc, out_filename);
 
         info!("[RunnerContext::download_package] writing to {}", out_loc);

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -6,7 +6,8 @@ use log::{debug,
           error,
           info};
 
-use crate::{depends,
+use crate::{appvar::AppVarData,
+            depends,
             helper,
             helper::{find_sourcemod_path,
                      parse_location,
@@ -16,7 +17,6 @@ use crate::{depends,
                       RemoteVersion,
                       RemoteVersionResponse},
             BeansError};
-use crate::appvar::AppVarData;
 
 #[derive(Debug, Clone)]
 pub struct RunnerContext
@@ -242,7 +242,10 @@ impl RunnerContext
 
     /// Download package with Progress Bar.
     /// Ok is the location to where it was downloaded to.
-    pub async fn download_package(version: RemoteVersion, version_id: usize) -> Result<String, BeansError>
+    pub async fn download_package(
+        version: RemoteVersion,
+        version_id: usize
+    ) -> Result<String, BeansError>
     {
         let av = AppVarData::get();
         let mut out_loc = helper::get_tmp_dir();
@@ -255,7 +258,8 @@ impl RunnerContext
             }
         }
 
-        let out_filename = match crate::aria2::can_use_aria2() {
+        let out_filename = match crate::aria2::can_use_aria2()
+        {
             true => format!("{}_{}.pkg", av.mod_info.sourcemod_name, version_id),
             false => format!("presz_{}", helper::generate_rand_str(12))
         };
@@ -335,8 +339,7 @@ impl RunnerContext
                 {
                     debug!(
                         "[RunnerContext::prepare_symlink] failed to remove {}\n{:#?}",
-                        ln_location,
-                        e
+                        ln_location, e
                     );
                     return Err(e.into());
                 }

--- a/src/depends.rs
+++ b/src/depends.rs
@@ -8,10 +8,12 @@ use log::{debug,
 
 use crate::{helper,
             BeansError,
-            ARIA2C_BINARY,
             BUTLER_BINARY,
             BUTLER_LIB_1,
             BUTLER_LIB_2};
+
+#[cfg(target_os = "windows")]
+use crate::ARIA2C_BINARY;
 
 /// try and write aria2c and butler if it doesn't exist
 /// paths that are used will be fetched from binary_locations()
@@ -20,6 +22,7 @@ pub fn try_write_deps()
     safe_write_file(get_butler_location().as_str(), &BUTLER_BINARY);
     safe_write_file(get_butler_1_location().as_str(), &BUTLER_LIB_1);
     safe_write_file(get_butler_2_location().as_str(), &BUTLER_LIB_2);
+    #[cfg(target_os = "windows")]
     if let Some(s) = get_aria2c_location()
     {
         safe_write_file(s.as_str(), &ARIA2C_BINARY);
@@ -186,5 +189,4 @@ const BUTLER_2: &str = "c7zip.dll";
 #[cfg(not(target_os = "windows"))]
 const BUTLER_2: &str = "libc7zip.so";
 
-#[cfg(target_os = "windows")]
 const ARIA2C_LOCATION: &str = "aria2c.exe";

--- a/src/depends.rs
+++ b/src/depends.rs
@@ -8,10 +8,10 @@ use log::{debug,
 
 use crate::{helper,
             BeansError,
+            ARIA2C_BINARY,
             BUTLER_BINARY,
             BUTLER_LIB_1,
-            BUTLER_LIB_2,
-            ARIA2C_BINARY};
+            BUTLER_LIB_2};
 
 /// try and write aria2c and butler if it doesn't exist
 /// paths that are used will be fetched from binary_locations()
@@ -20,7 +20,8 @@ pub fn try_write_deps()
     safe_write_file(get_butler_location().as_str(), &BUTLER_BINARY);
     safe_write_file(get_butler_1_location().as_str(), &BUTLER_LIB_1);
     safe_write_file(get_butler_2_location().as_str(), &BUTLER_LIB_2);
-    if let Some(s) = get_aria2c_location() {
+    if let Some(s) = get_aria2c_location()
+    {
         safe_write_file(s.as_str(), &ARIA2C_BINARY);
     }
     #[cfg(not(target_os = "windows"))]
@@ -157,7 +158,8 @@ pub fn get_butler_2_location() -> String
 /// Will always return `Some()` on Windows, and `None` on any other platform.
 pub fn get_aria2c_location() -> Option<String>
 {
-    if cfg!(target_os = "windows") {
+    if cfg!(target_os = "windows")
+    {
         let mut path = get_tmp_dir();
         path.push_str(ARIA2C_LOCATION);
         return Some(path);

--- a/src/depends.rs
+++ b/src/depends.rs
@@ -6,14 +6,13 @@ use std::os::unix::fs::PermissionsExt;
 use log::{debug,
           error};
 
+#[cfg(target_os = "windows")]
+use crate::ARIA2C_BINARY;
 use crate::{helper,
             BeansError,
             BUTLER_BINARY,
             BUTLER_LIB_1,
             BUTLER_LIB_2};
-
-#[cfg(target_os = "windows")]
-use crate::ARIA2C_BINARY;
 
 /// try and write aria2c and butler if it doesn't exist
 /// paths that are used will be fetched from binary_locations()

--- a/src/depends.rs
+++ b/src/depends.rs
@@ -10,7 +10,8 @@ use crate::{helper,
             BeansError,
             BUTLER_BINARY,
             BUTLER_LIB_1,
-            BUTLER_LIB_2};
+            BUTLER_LIB_2,
+            ARIA2C_BINARY};
 
 /// try and write aria2c and butler if it doesn't exist
 /// paths that are used will be fetched from binary_locations()
@@ -19,6 +20,9 @@ pub fn try_write_deps()
     safe_write_file(get_butler_location().as_str(), &BUTLER_BINARY);
     safe_write_file(get_butler_1_location().as_str(), &BUTLER_LIB_1);
     safe_write_file(get_butler_2_location().as_str(), &BUTLER_LIB_2);
+    if let Some(s) = get_aria2c_location() {
+        safe_write_file(s.as_str(), &ARIA2C_BINARY);
+    }
     #[cfg(not(target_os = "windows"))]
     if helper::file_exists(get_butler_location())
     {
@@ -150,6 +154,16 @@ pub fn get_butler_2_location() -> String
     path.push_str(BUTLER_2);
     path
 }
+/// Will always return `Some()` on Windows, and `None` on any other platform.
+pub fn get_aria2c_location() -> Option<String>
+{
+    if cfg!(target_os = "windows") {
+        let mut path = get_tmp_dir();
+        path.push_str(ARIA2C_LOCATION);
+        return Some(path);
+    }
+    None
+}
 fn get_tmp_dir() -> String
 {
     let path = helper::get_tmp_dir();
@@ -169,3 +183,6 @@ const BUTLER_1: &str = "7z.so";
 const BUTLER_2: &str = "c7zip.dll";
 #[cfg(not(target_os = "windows"))]
 const BUTLER_2: &str = "libc7zip.so";
+
+#[cfg(target_os = "windows")]
+const ARIA2C_LOCATION: &str = "aria2c.exe";

--- a/src/error.rs
+++ b/src/error.rs
@@ -219,6 +219,92 @@ pub enum BeansError
     GameStillRunning
     {
         name: String, pid: String
+    },
+
+    #[error("Aria2c exited with code {reason:#?}")]
+    Aria2cExitCode
+    {
+        reason: Aria2cExitCodeReason,
+        cmd: String,
+        backtrace: Backtrace
+    }
+}
+#[derive(Debug)]
+pub enum Aria2cExitCodeReason
+{
+    UnknownError,
+    Timeout,
+    ResourceNotFound,
+    ResourceNotFoundLimitReached,
+    AbortedDueToSlowDownloadSpeed,
+    NetworkProblem,
+    ExitedWithUnfinishedDownloads,
+    RemoteServerDoesNotSupportResume,
+    NotEnoughDiskSpace,
+    PieceLengthMismatch,
+    AlreadyDownloadingFile,
+    AlreadyDownloadingFileWithSameTorrentHash,
+    OutputFileAlreadyExists,
+    OutputFileRenameFailure,
+    CouldNotOpenOutputFile,
+    CouldNotCreateOutputFile,
+    IOError,
+    CouldNotCreateDirectory,
+    NameResolutionFailure,
+    CouldNotParseMetalinkDocument,
+    FTPCommandFailure,
+    BadHttpResponseHeader,
+    TooManyHttpRedirects,
+    HttpAuthorizeFailure,
+    CouldNotParseBencodedFile,
+    CorruptTorrentFile,
+    BadMagnetUri,
+    BadOrUnrecognizedOptionOrInvalidArgument,
+    RemoteServerFailureDueToOverloadingOrMaintenance,
+    JsonRpcRequestParseFailure,
+    ChecksumValidationFailure,
+
+    Unknown(i32)
+}
+impl Aria2cExitCodeReason {
+    pub fn from_exit_code(code: i32) -> Option<Aria2cExitCodeReason> {
+        if code <= 0 {
+            return None;
+        }
+        match code {
+            1 => Some(Aria2cExitCodeReason::UnknownError),
+            2 => Some(Aria2cExitCodeReason::Timeout),
+            3 => Some(Aria2cExitCodeReason::ResourceNotFound),
+            4 => Some(Aria2cExitCodeReason::ResourceNotFoundLimitReached),
+            5 => Some(Aria2cExitCodeReason::AbortedDueToSlowDownloadSpeed),
+            6 => Some(Aria2cExitCodeReason::NetworkProblem),
+            7 => Some(Aria2cExitCodeReason::ExitedWithUnfinishedDownloads),
+            8 => Some(Aria2cExitCodeReason::RemoteServerDoesNotSupportResume),
+            9 => Some(Aria2cExitCodeReason::NotEnoughDiskSpace),
+            10 => Some(Aria2cExitCodeReason::PieceLengthMismatch),
+            11 => Some(Aria2cExitCodeReason::AlreadyDownloadingFile),
+            12 => Some(Aria2cExitCodeReason::AlreadyDownloadingFileWithSameTorrentHash),
+            13 => Some(Aria2cExitCodeReason::OutputFileAlreadyExists),
+            14 => Some(Aria2cExitCodeReason::OutputFileRenameFailure),
+            15 => Some(Aria2cExitCodeReason::CouldNotOpenOutputFile),
+            16 => Some(Aria2cExitCodeReason::CouldNotCreateOutputFile),
+            17 => Some(Aria2cExitCodeReason::IOError),
+            18 => Some(Aria2cExitCodeReason::CouldNotCreateDirectory),
+            19 => Some(Aria2cExitCodeReason::NameResolutionFailure),
+            20 => Some(Aria2cExitCodeReason::CouldNotParseMetalinkDocument),
+            21 => Some(Aria2cExitCodeReason::FTPCommandFailure),
+            22 => Some(Aria2cExitCodeReason::BadHttpResponseHeader),
+            23 => Some(Aria2cExitCodeReason::TooManyHttpRedirects),
+            24 => Some(Aria2cExitCodeReason::HttpAuthorizeFailure),
+            25 => Some(Aria2cExitCodeReason::CouldNotParseBencodedFile),
+            26 => Some(Aria2cExitCodeReason::CorruptTorrentFile),
+            27 => Some(Aria2cExitCodeReason::BadMagnetUri),
+            28 => Some(Aria2cExitCodeReason::BadOrUnrecognizedOptionOrInvalidArgument),
+            29 => Some(Aria2cExitCodeReason::RemoteServerFailureDueToOverloadingOrMaintenance),
+            30 => Some(Aria2cExitCodeReason::JsonRpcRequestParseFailure),
+            32 => Some(Aria2cExitCodeReason::ChecksumValidationFailure),
+            _ => Some(Aria2cExitCodeReason::Unknown(code)),
+        }
     }
 }
 #[derive(Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -318,6 +318,13 @@ pub enum DownloadFailureReason
     FileNotFound
     {
         location: String
+    },
+    MissingAria2cExecutable,
+    Aria2cSpawnError
+    {
+        url: String,
+        output_file: String,
+        error: std::io::Error
     }
 }
 #[derive(Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,7 +83,8 @@ pub enum BeansError
     #[error("Failed to download file\n{reason:#?}")]
     DownloadFailure
     {
-        reason: DownloadFailureReason
+        reason: DownloadFailureReason,
+        backtrace: Backtrace
     },
 
     #[error("General IO Error\n{error:#?}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -266,12 +266,16 @@ pub enum Aria2cExitCodeReason
 
     Unknown(i32)
 }
-impl Aria2cExitCodeReason {
-    pub fn from_exit_code(code: i32) -> Option<Aria2cExitCodeReason> {
-        if code <= 0 {
+impl Aria2cExitCodeReason
+{
+    pub fn from_exit_code(code: i32) -> Option<Aria2cExitCodeReason>
+    {
+        if code <= 0
+        {
             return None;
         }
-        match code {
+        match code
+        {
             1 => Some(Aria2cExitCodeReason::UnknownError),
             2 => Some(Aria2cExitCodeReason::Timeout),
             3 => Some(Aria2cExitCodeReason::ResourceNotFound),
@@ -303,7 +307,7 @@ impl Aria2cExitCodeReason {
             29 => Some(Aria2cExitCodeReason::RemoteServerFailureDueToOverloadingOrMaintenance),
             30 => Some(Aria2cExitCodeReason::JsonRpcRequestParseFailure),
             32 => Some(Aria2cExitCodeReason::ChecksumValidationFailure),
-            _ => Some(Aria2cExitCodeReason::Unknown(code)),
+            _ => Some(Aria2cExitCodeReason::Unknown(code))
         }
     }
 }
@@ -312,7 +316,8 @@ pub enum DownloadFailureReason
 {
     Reqwest
     {
-        url: String, error: reqwest::Error
+        url: String,
+        error: reqwest::Error
     },
     /// The downloaded file could not be found, perhaps it failed?
     FileNotFound

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -3,25 +3,27 @@ use std::{backtrace::Backtrace,
 
 use indicatif::{ProgressBar,
                 ProgressStyle};
-use log::{info,
-          debug,
-          error};
+use log::{debug,
+          error,
+          info};
 use zstd::stream::read::Decoder as ZstdDecoder;
 
 use crate::BeansError;
 
-fn unpack_tarball_getfile(tarball_location: String, output_directory: String) -> Result<File, BeansError>
+fn unpack_tarball_getfile(
+    tarball_location: String,
+    output_directory: String
+) -> Result<File, BeansError>
 {
-    match File::open(&tarball_location) {
+    match File::open(&tarball_location)
+    {
         Ok(x) => Ok(x),
-        Err(e) => {
-            Err(BeansError::TarExtractFailure {
-                src_file: tarball_location,
-                target_dir: output_directory,
-                error: e,
-                backtrace: Backtrace::capture(),
-            })
-        }
+        Err(e) => Err(BeansError::TarExtractFailure {
+            src_file: tarball_location,
+            target_dir: output_directory,
+            error: e,
+            backtrace: Backtrace::capture()
+        })
     }
 }
 

--- a/src/gui/dialog.rs
+++ b/src/gui/dialog.rs
@@ -1,6 +1,6 @@
 use fltk::{image::PngImage,
-           text::TextBuffer,
            prelude::*,
+           text::TextBuffer,
            *};
 use log::warn;
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -87,14 +87,17 @@ pub fn apply_app_scheme()
 {
     let theme_content = match dark_light::detect()
     {
-        Ok(c) => {
-            match c {
-                dark_light::Mode::Light => color_themes::GRAY_THEME,
-                _ => color_themes::DARK_THEME
-            }
+        Ok(c) => match c
+        {
+            dark_light::Mode::Light => color_themes::GRAY_THEME,
+            _ => color_themes::DARK_THEME
         },
-        Err(e) => {
-            log::warn!("[gui::apply_app_scheme] Failed to detect light/dark mode\n{:#?}", e);
+        Err(e) =>
+        {
+            log::warn!(
+                "[gui::apply_app_scheme] Failed to detect light/dark mode\n{:#?}",
+                e
+            );
             color_themes::DARK_THEME
         }
     };

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -977,3 +977,25 @@ pub fn payload_message(info: &std::panic::PanicHookInfo) -> String {
         String::from("<unknown error> (unhandled downcast_ref in payload_message)")
     }
 }
+
+/// Check if a program exists in the PATH environment variable folders.
+pub fn program_in_path(name: String) -> bool {
+    get_program_env_location(name).is_some()
+}
+
+/// Get the full executable path for an executable found in the PATH
+/// environment variable.
+///
+/// Derived from https://stackoverflow.com/a/35046243/13037015
+pub fn get_program_env_location(name: String) -> Option<String> {
+    if let Ok(path) = std::env::var("PATH") {
+        for p in path.split(":") {
+            let mut p_str = format_directory_path(p.to_string());
+            p_str.push_str(name.as_str());
+            if std::fs::metadata(&p_str).is_ok() {
+                return Some(p_str);
+            }
+        }
+    }
+    None
+}

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -12,7 +12,6 @@ mod windows;
 use std::{collections::HashMap,
           io::Write,
           path::PathBuf};
-
 use futures::StreamExt;
 use indicatif::{ProgressBar,
                 ProgressStyle};
@@ -237,6 +236,21 @@ pub fn format_directory_path(location: String) -> String
         x.push_str(crate::PATH_SEP);
     }
     x
+}
+
+/// Get the filename of the location provided.
+/// 
+/// If the result is an empty string, then the location provided is invalid, and you should
+/// check that yourself :3
+pub fn get_filename(location: String) -> String
+{
+    let mut x = location.to_string().replace(['/', '\\'], crate::PATH_SEP);
+    let xr = x.split(crate::PATH_SEP);
+    if let Some(p) = xr.last() {
+        p.to_string()
+    } else {
+        String::new()
+    }
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -451,9 +451,24 @@ pub fn has_free_space(
     Ok((size as u64) < get_free_space(location)?)
 }
 
+
+pub async fn download_with_progress(
+    url: String,
+    out_location: String
+) -> Result<(), BeansError>
+{
+    debug!("[helper::download_with_progress] url: {}, out_location: {}", url, out_location);
+    if crate::aria2::can_use_aria2() {
+        debug!("[helper::download_with_progress] using aria2c");
+        crate::aria2::download_file(url, out_location).await?;
+    } else {
+        download_with_progress_reqwest(url, out_location).await?;
+    }
+    Ok(())
+}
 /// Download file at the URL provided to the output location provided
 /// This function will also show a progress bar with indicatif.
-pub async fn download_with_progress(
+async fn download_with_progress_reqwest(
     url: String,
     out_location: String
 ) -> Result<(), BeansError>

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -245,7 +245,7 @@ pub fn format_directory_path(location: String) -> String
 /// you should check that yourself :3
 pub fn get_filename(location: String) -> String
 {
-    let mut x = location.to_string().replace(['/', '\\'], crate::PATH_SEP);
+    let x = location.to_string().replace(['/', '\\'], crate::PATH_SEP);
     let xr = x.split(crate::PATH_SEP);
     if let Some(p) = xr.last()
     {

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -454,7 +454,8 @@ pub async fn download_with_progress(
                 reason: DownloadFailureReason::Reqwest {
                     url: url.clone(),
                     error: e
-                }
+                },
+                backtrace: std::backtrace::Backtrace::capture()
             });
         }
     };

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -12,6 +12,7 @@ mod windows;
 use std::{collections::HashMap,
           io::Write,
           path::PathBuf};
+
 use futures::StreamExt;
 use indicatif::{ProgressBar,
                 ProgressStyle};
@@ -240,15 +241,18 @@ pub fn format_directory_path(location: String) -> String
 
 /// Get the filename of the location provided.
 ///
-/// If the result is an empty string, then the location provided is invalid, and you should
-/// check that yourself :3
+/// If the result is an empty string, then the location provided is invalid, and
+/// you should check that yourself :3
 pub fn get_filename(location: String) -> String
 {
     let mut x = location.to_string().replace(['/', '\\'], crate::PATH_SEP);
     let xr = x.split(crate::PATH_SEP);
-    if let Some(p) = xr.last() {
+    if let Some(p) = xr.last()
+    {
         p.to_string()
-    } else {
+    }
+    else
+    {
         String::new()
     }
 }
@@ -326,15 +330,19 @@ fn is_process_running(
 ) -> Option<sysinfo::Pid>
 {
     find_process(move |proc: &sysinfo::Process| {
-        if let Some(proc_name_str) = proc.name().to_str() {
+        if let Some(proc_name_str) = proc.name().to_str()
+        {
             let proc_name = proc_name_str.to_string();
-            if proc_name == name {
+            if proc_name == name
+            {
                 if let Some(x) = arguments_contains.clone()
                 {
                     for item in proc.cmd().iter()
                     {
-                        if let Some(item_str) = item.to_str() {
-                            if item_str.starts_with(&x) {
+                        if let Some(item_str) = item.to_str()
+                        {
+                            if item_str.starts_with(&x)
+                            {
                                 return true;
                             }
                         }
@@ -391,11 +399,13 @@ pub fn is_game_running(mod_directory: String) -> Option<sysinfo::Pid>
     if let Some(proc) = find_process(move |proc| {
         for item in proc.cmd().iter()
         {
-            if let Some(os_str) = item.to_str() {
+            if let Some(os_str) = item.to_str()
+            {
                 let os_string = os_str.to_string();
                 if os_string.starts_with(&mod_directory)
                 {
-                    if let Some(proc_name_str) = proc.name().to_str() {
+                    if let Some(proc_name_str) = proc.name().to_str()
+                    {
                         let proc_name = proc_name_str.to_string().to_lowercase();
                         if proc_name != *"beans" && proc_name != *"beans-rs"
                         {
@@ -451,17 +461,22 @@ pub fn has_free_space(
     Ok((size as u64) < get_free_space(location)?)
 }
 
-
 pub async fn download_with_progress(
     url: String,
     out_location: String
 ) -> Result<(), BeansError>
 {
-    debug!("[helper::download_with_progress] url: {}, out_location: {}", url, out_location);
-    if crate::aria2::can_use_aria2() && !crate::env_disable_aria2c() {
+    debug!(
+        "[helper::download_with_progress] url: {}, out_location: {}",
+        url, out_location
+    );
+    if crate::aria2::can_use_aria2() && !crate::env_disable_aria2c()
+    {
         debug!("[helper::download_with_progress] using aria2c");
         crate::aria2::download_file(url, out_location).await?;
-    } else {
+    }
+    else
+    {
         download_with_progress_reqwest(url, out_location).await?;
     }
     Ok(())
@@ -983,18 +998,25 @@ pub fn try_get_env_var(target_key: String) -> Option<String>
 }
 
 /// Get the message used from the info passed to std::panic::set_hook.
-pub fn payload_message(info: &std::panic::PanicHookInfo) -> String {
-    if let Some(s) = info.payload().downcast_ref::<&str>() {
+pub fn payload_message(info: &std::panic::PanicHookInfo) -> String
+{
+    if let Some(s) = info.payload().downcast_ref::<&str>()
+    {
         String::from(*s)
-    } else if let Some(s) = info.payload().downcast_ref::<String>() {
+    }
+    else if let Some(s) = info.payload().downcast_ref::<String>()
+    {
         s.clone()
-    } else {
+    }
+    else
+    {
         String::from("<unknown error> (unhandled downcast_ref in payload_message)")
     }
 }
 
 /// Check if a program exists in the PATH environment variable folders.
-pub fn program_in_path(name: String) -> bool {
+pub fn program_in_path(name: String) -> bool
+{
     get_program_env_location(name).is_some()
 }
 
@@ -1002,12 +1024,16 @@ pub fn program_in_path(name: String) -> bool {
 /// environment variable.
 ///
 /// Derived from https://stackoverflow.com/a/35046243/13037015
-pub fn get_program_env_location(name: String) -> Option<String> {
-    if let Ok(path) = std::env::var("PATH") {
-        for p in path.split(":") {
+pub fn get_program_env_location(name: String) -> Option<String>
+{
+    if let Ok(path) = std::env::var("PATH")
+    {
+        for p in path.split(":")
+        {
             let mut p_str = format_directory_path(p.to_string());
             p_str.push_str(name.as_str());
-            if std::fs::metadata(&p_str).is_ok() {
+            if std::fs::metadata(&p_str).is_ok()
+            {
                 return Some(p_str);
             }
         }

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -239,7 +239,7 @@ pub fn format_directory_path(location: String) -> String
 }
 
 /// Get the filename of the location provided.
-/// 
+///
 /// If the result is an empty string, then the location provided is invalid, and you should
 /// check that yourself :3
 pub fn get_filename(location: String) -> String
@@ -458,7 +458,7 @@ pub async fn download_with_progress(
 ) -> Result<(), BeansError>
 {
     debug!("[helper::download_with_progress] url: {}, out_location: {}", url, out_location);
-    if crate::aria2::can_use_aria2() {
+    if crate::aria2::can_use_aria2() && !crate::env_disable_aria2c() {
         debug!("[helper::download_with_progress] using aria2c");
         crate::aria2::download_file(url, out_location).await?;
     } else {

--- a/src/helper/windows.rs
+++ b/src/helper/windows.rs
@@ -19,25 +19,18 @@ pub fn find_sourcemod_path() -> Result<String, BeansError>
             match x
             {
                 Ok(val) => Ok(format_directory_path(val)),
-                Err(e) =>
-                {
-                    Err(BeansError::RegistryKeyFailure {
-                        msg: "Failed to find HKCU\\Software\\Valve. Steam might not be installed"
-                            .to_string(),
-                        error: e,
-                        backtrace: Backtrace::capture()
-                    })
-                }
+                Err(e) => Err(BeansError::RegistryKeyFailure {
+                    msg: "Failed to find HKCU\\Software\\Valve. Steam might not be installed"
+                        .to_string(),
+                    error: e,
+                    backtrace: Backtrace::capture()
+                })
             }
         }
-        Err(e) =>
-        {
-            Err(BeansError::RegistryKeyFailure {
-                msg: "Failed to find HKCU\\Software\\Valve. Steam might not be installed"
-                    .to_string(),
-                error: e,
-                backtrace: Backtrace::capture()
-            })
-        }
+        Err(e) => Err(BeansError::RegistryKeyFailure {
+            msg: "Failed to find HKCU\\Software\\Valve. Steam might not be installed".to_string(),
+            error: e,
+            backtrace: Backtrace::capture()
+        })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,10 @@ pub fn env_headless() -> bool
     check_env_bool("BEANS_HEADLESS") || check_env_bool("ADASTRAL_HEADLESS")
 }
 
+/// Return `true` when the environment variable `BEANS_DISABLE_ARIA2C` or
+/// `ADASTRAL_DISABLE_ARIA2C` exists and equals `1` or `true`.
+pub fn env_disable_aria2c() -> bool { check_env_bool("BEANS_DISABLE_ARIA2C") || check_env_bool("ADASTRAL_DISABLE_ARIA2C") }
+
 /// Return `true` when the environment variable exists, and it's value equals
 /// `1` or `true (when trimmed and made lowercase).
 fn check_env_bool<K: AsRef<std::ffi::OsStr>>(key: K) -> bool

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,13 @@ pub fn has_gui_support() -> bool
     }
 }
 
+/// User agent for downloading files or sending web requests.
+pub fn get_user_agent() -> String {
+    let mut result = String::from("beans-rs/");
+    result.push_str(&VERSION);
+    result
+}
+
 #[cfg(not(target_os = "windows"))]
 pub const STAGING_DIR: &str = "/butler-staging";
 #[cfg(target_os = "windows")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![feature(error_generic_member_access)]
+// required for aria2::get_executable_location()
+#![feature(let_chains)]
 // todo
 // https://rust-lang.github.io/rust-clippy/master/index.html#/result_large_err
 #![allow(clippy::result_large_err)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ pub mod flags;
 pub mod gui;
 pub mod logger;
 
+pub mod aria2;
+
 /// NOTE do not change, fetches from the version of beans-rs on build
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// sentry url, change on fork please.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,3 +162,5 @@ flate!(pub static BUTLER_LIB_1: [u8] from "Binaries/7z.so");
 flate!(pub static BUTLER_LIB_2: [u8] from "Binaries/c7zip.dll");
 #[cfg(not(target_os = "windows"))]
 flate!(pub static BUTLER_LIB_2: [u8] from "Binaries/libc7zip.so");
+#[cfg(target_os = "windows")]
+flate!(pub static ARIA2C_BINARY: [u8] from "Binaries/aria2c.exe");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub use ctx::*;
 mod error;
 
 pub use error::*;
+
 use crate::appvar::AppVarData;
 
 pub mod appvar;
@@ -91,7 +92,10 @@ pub fn env_headless() -> bool
 
 /// Return `true` when the environment variable `BEANS_DISABLE_ARIA2C` or
 /// `ADASTRAL_DISABLE_ARIA2C` exists and equals `1` or `true`.
-pub fn env_disable_aria2c() -> bool { check_env_bool("BEANS_DISABLE_ARIA2C") || check_env_bool("ADASTRAL_DISABLE_ARIA2C") }
+pub fn env_disable_aria2c() -> bool
+{
+    check_env_bool("BEANS_DISABLE_ARIA2C") || check_env_bool("ADASTRAL_DISABLE_ARIA2C")
+}
 
 /// Return `true` when the environment variable exists, and it's value equals
 /// `1` or `true (when trimmed and made lowercase).
@@ -152,7 +156,8 @@ pub fn has_gui_support() -> bool
 }
 
 /// User agent for downloading files or sending web requests.
-pub fn get_user_agent() -> String {
+pub fn get_user_agent() -> String
+{
     let mut result = String::from("beans-rs/");
     result.push_str(&VERSION);
     result

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,10 @@ fn main()
     }));
     init_panic_handle();
 
+    if !beans_rs::aria2::get_executable_location().is_none() {
+        info!("Could not find aria2c!\nFor faster downloads, install it with your package manager (usually called \"aria2\")");
+    }
+
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,10 +49,14 @@ fn main()
     init_panic_handle();
     if !beans_rs::env_disable_aria2c()
     {
-        if !beans_rs::aria2::get_executable_location().is_none()
+        if beans_rs::aria2::get_executable_location().is_none()
         {
             info!("Could not find aria2c!\nFor faster downloads, install it with your package manager (usually called \"aria2\")");
         }
+    }
+
+    if beans_rs::env_disable_aria2c() && beans_rs::aria2::get_executable_location().is_some() {
+        info!("== aria2c support disabled, even though it's available ==");
     }
 
     tokio::runtime::Builder::new_multi_thread()

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,9 +47,10 @@ fn main()
         ..Default::default()
     }));
     init_panic_handle();
-
-    if !beans_rs::aria2::get_executable_location().is_none() {
-        info!("Could not find aria2c!\nFor faster downloads, install it with your package manager (usually called \"aria2\")");
+    if !beans_rs::env_disable_aria2c() {
+        if !beans_rs::aria2::get_executable_location().is_none() {
+            info!("Could not find aria2c!\nFor faster downloads, install it with your package manager (usually called \"aria2\")");
+        }
     }
 
     tokio::runtime::Builder::new_multi_thread()

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,8 @@ fn main()
         }
     }
 
-    if beans_rs::env_disable_aria2c() && beans_rs::aria2::get_executable_location().is_some() {
+    if beans_rs::env_disable_aria2c() && beans_rs::aria2::get_executable_location().is_some()
+    {
         info!("== aria2c support disabled, even though it's available ==");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,8 +47,10 @@ fn main()
         ..Default::default()
     }));
     init_panic_handle();
-    if !beans_rs::env_disable_aria2c() {
-        if !beans_rs::aria2::get_executable_location().is_none() {
+    if !beans_rs::env_disable_aria2c()
+    {
+        if !beans_rs::aria2::get_executable_location().is_none()
+        {
             info!("Could not find aria2c!\nFor faster downloads, install it with your package manager (usually called \"aria2\")");
         }
     }
@@ -66,14 +68,21 @@ fn main()
 fn init_console()
 {
     winconsole::window::show(true);
-    if let Err(e) = winconsole::console::set_title(format!("beans v{}", beans_rs::VERSION).as_str()) {
+    if let Err(e) = winconsole::console::set_title(format!("beans v{}", beans_rs::VERSION).as_str())
+    {
         trace!("[init_console] failed to set console title {:#?}", e);
     }
-    if let Ok(mut input_mode) = winconsole::console::get_input_mode() {
-        if input_mode.QuickEditMode {
+    if let Ok(mut input_mode) = winconsole::console::get_input_mode()
+    {
+        if input_mode.QuickEditMode
+        {
             input_mode.QuickEditMode = false;
-            if let Err(e) = winconsole::console::set_input_mode(input_mode) {
-                debug!("[init_console] failed to disable console flag QuickEditMode {:#?}", e);
+            if let Err(e) = winconsole::console::set_input_mode(input_mode)
+            {
+                debug!(
+                    "[init_console] failed to disable console flag QuickEditMode {:#?}",
+                    e
+                );
                 warn!("[init_console] failed to disable Quick Edit mode ({:})", e);
             }
         }
@@ -289,7 +298,10 @@ impl Launcher
                 }
             }
             sml_dir_manual = Some(parse_location(x.to_string()));
-            info!("[Launcher::find_arg_sourcemods_location] Found in arguments! {}", x);
+            info!(
+                "[Launcher::find_arg_sourcemods_location] Found in arguments! {}",
+                x
+            );
         }
         sml_dir_manual
     }

--- a/src/version.rs
+++ b/src/version.rs
@@ -7,11 +7,11 @@ use log::{debug,
           error,
           trace};
 
-use crate::{helper,
+use crate::{appvar::AppVarData,
+            helper,
             helper::{find_sourcemod_path,
                      InstallType},
             BeansError};
-use crate::appvar::AppVarData;
 
 /// get the current version installed via the .adastral file in the sourcemod
 /// mod folder. will parse the value of `version` as usize.

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -6,7 +6,8 @@ use log::{debug,
           info,
           trace};
 
-use crate::{depends,
+use crate::{appvar::AppVarData,
+            depends,
             flags,
             flags::LaunchFlag,
             helper,
@@ -21,7 +22,6 @@ use crate::{depends,
             BeansError,
             RunnerContext,
             SourceModDirectoryParam};
-use crate::appvar::AppVarData;
 
 #[derive(Debug, Clone)]
 pub struct WizardContext

--- a/src/workflows/clean.rs
+++ b/src/workflows/clean.rs
@@ -31,7 +31,7 @@ impl CleanWorkflow
             return Err(BeansError::CleanTempFailure {
                 location: target_directory,
                 error: e,
-                backtrace: std::backtrace::Backtrace::capture(),
+                backtrace: std::backtrace::Backtrace::capture()
             });
         }
 
@@ -42,7 +42,7 @@ impl CleanWorkflow
             return Err(BeansError::DirectoryCreateFailure {
                 location: target_directory,
                 error: e,
-                backtrace: std::backtrace::Backtrace::capture(),
+                backtrace: std::backtrace::Backtrace::capture()
             });
         }
 

--- a/src/workflows/install.rs
+++ b/src/workflows/install.rs
@@ -2,7 +2,6 @@ use log::{debug,
           error,
           info,
           warn};
-
 use crate::{appvar::AppVarData,
             helper,
             version::{AdastralVersionFile,
@@ -193,10 +192,25 @@ impl InstallWorkflow
         {
             warn!("Not writing .adastral since the version wasn't provided");
         }
+        InstallWorkflow::install_from_post();
+        Ok(())
+    }
+    fn install_from_post() {
         let av = AppVarData::get();
         println!("{}", av.sub(INSTALL_FINISH_MSG.to_string()));
         debug!("[InstallWorkflow::install_from] Displayed INSTALL_FINISH_MSG");
-        Ok(())
+
+        #[cfg(target_os = "windows")]
+        winconsole::window::show(true);
+        #[cfg(target_os = "windows")]
+        winconsole::window::flash(winconsole::window::FlashInfo {
+            count: 0,
+            flash_caption: true,
+            flash_tray: true,
+            indefinite: false,
+            rate: 0,
+            until_foreground: true,
+        });
     }
 }
 

--- a/src/workflows/install.rs
+++ b/src/workflows/install.rs
@@ -154,7 +154,8 @@ impl InstallWorkflow
             return Err(BeansError::DownloadFailure {
                 reason: DownloadFailureReason::FileNotFound {
                     location: package_loc.clone()
-                }
+                },
+                backtrace: std::backtrace::Backtrace::capture()
             });
         }
         if !helper::dir_exists(out_dir.clone())

--- a/src/workflows/install.rs
+++ b/src/workflows/install.rs
@@ -119,7 +119,7 @@ impl InstallWorkflow
             "{:=>60}\nInstalling version {} to {}\n{0:=>60}",
             "=", version_id, &ctx.sourcemod_path
         );
-        let presz_loc = RunnerContext::download_package(version).await?;
+        let presz_loc = RunnerContext::download_package(version, version_id).await?;
         Self::install_from(
             presz_loc.clone(),
             ctx.sourcemod_path.clone(),

--- a/src/workflows/install.rs
+++ b/src/workflows/install.rs
@@ -2,6 +2,7 @@ use log::{debug,
           error,
           info,
           warn};
+
 use crate::{appvar::AppVarData,
             helper,
             version::{AdastralVersionFile,
@@ -166,7 +167,7 @@ impl InstallWorkflow
                 return Err(BeansError::DirectoryCreateFailure {
                     location: out_dir.clone(),
                     error: e,
-                    backtrace: std::backtrace::Backtrace::capture(),
+                    backtrace: std::backtrace::Backtrace::capture()
                 });
             }
         }
@@ -195,7 +196,8 @@ impl InstallWorkflow
         InstallWorkflow::install_from_post();
         Ok(())
     }
-    fn install_from_post() {
+    fn install_from_post()
+    {
         let av = AppVarData::get();
         println!("{}", av.sub(INSTALL_FINISH_MSG.to_string()));
         debug!("[InstallWorkflow::install_from] Displayed INSTALL_FINISH_MSG");
@@ -209,7 +211,7 @@ impl InstallWorkflow
             flash_tray: true,
             indefinite: false,
             rate: 0,
-            until_foreground: true,
+            until_foreground: true
         });
     }
 }

--- a/src/workflows/update.rs
+++ b/src/workflows/update.rs
@@ -1,11 +1,11 @@
 use log::{debug,
           info};
 
-use crate::{butler,
+use crate::{appvar::AppVarData,
+            butler,
             helper,
             BeansError,
             RunnerContext};
-use crate::appvar::AppVarData;
 
 pub struct UpdateWorkflow
 {

--- a/src/workflows/verify.rs
+++ b/src/workflows/verify.rs
@@ -1,9 +1,9 @@
-use crate::{butler,
+use crate::{appvar::AppVarData,
+            butler,
             helper,
             version::RemoteVersion,
             BeansError,
             RunnerContext};
-use crate::appvar::AppVarData;
 
 pub struct VerifyWorkflow
 {


### PR DESCRIPTION
This PR adds support for downloading with aria2c instead of request. By default this feature is enabled, but it can be disabled by setting the environment variable `BEANS_DISABLE_ARIA2C` (or `ADASTRAL_DISABLE_ARIA2C`) to `1` or `true`.

Along with adding aria2c support, the console window will also flash once the application/game has finished installing. (only on Windows)