### PR TITLE
chore: update Cargo description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Kate Ward <kate@dariox.club>",
     "ToastXC <contact@toastxc.xyz>"
 ]
-description = "Installer for Open Fortress"
+description = "Open-Source Installer for Sourcemods"
 repository = "https://github.com/ktwrd/beans-rs"
 license = "GPL-3.0"
 


### PR DESCRIPTION
Nitpick change to `Cargo.toml` description to match the `beans-rs` repo description.

`Installer for Open Fortress` -> `Open-Source Installer for Sourcemods`