### PR TITLE
housekeeping: Fix Actions failing due to code signing

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -18,7 +18,7 @@ jobs:
           - os: ubuntu-22.04
             filename: 'beans-rs'
             target: x86_64-unknown-linux-gnu
-          - os: windows-latest
+          - os: windows-2022
             target: x86_64-pc-windows-msvc
             filename: 'beans-rs.exe'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           certificate: '${{ secrets.CODESIGN }}'
           password: '${{ secrets.CODESIGN_PASSWORD }}'
-          folder: 'target/${{ matrix.target }}/debug/'
+          folder: 'target/${{ matrix.target }}/debug'
           description: 'beans-rs'
           certificatesha1: '${{ secrets.CODESIGN_HASH }}'
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           certificate: '${{ secrets.CODESIGN }}'
           password: '${{ secrets.CODESIGN_PASSWORD }}'
-          folder: 'target/${{ matrix.target }}/release/'
+          folder: 'target/${{ matrix.target }}/release'
           description: 'beans-rs'
           certificatesha1: '${{ secrets.CODESIGN_HASH }}'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
             filename: 'beans-rs'
             target: x86_64-unknown-linux-gnu
 
-          - os: windows-latest
+          - os: windows-2022
             target: x86_64-pc-windows-msvc
             filename: 'beans-rs.exe'
 


### PR DESCRIPTION
Fixed GH Actions failing due to invalid path used by the code signing step. This might've been caused by an update to the code signing action, but this should fix it?