### PR TITLE
fix: update rust toolchain action

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -52,10 +52,10 @@ jobs:
             libfltk1.3-dev \
             libssl-dev
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly-2025-01-10
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
 
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 # .github/workflows/release.yml
+name: Release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,10 @@ jobs:
             libfltk1.3-dev \
             libssl-dev
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly-2025-01-10
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
 
       - uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Replace Rust Toolchain installer with maintained fork
`actions-rs/toolchain@v1` -> `dtolnay/rust-toolchain@stable`