### PR TITLE
fix: codesigning step accidentally skipped

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -62,7 +62,7 @@ jobs:
           command: build
           args: --verbose --target ${{ matrix.target }}
       - name: Code Signing (Windows)
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-2022' }}
         uses: skymatic/code-sign-action@v1
         with:
           certificate: '${{ secrets.CODESIGN }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           args: --release --target ${{ matrix.target }}
 
       - name: Code Signing (Windows)
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-2022' }}
         uses: skymatic/code-sign-action@v1
         with:
           certificate: '${{ secrets.CODESIGN }}'


### PR DESCRIPTION
When changing the workflows to `2022` in the matrix os, the target for signing code was not updated.