### PR TITLE
feat: clean up command also removes butler-staging

### DIFF
--- a/src/workflows/clean.rs
+++ b/src/workflows/clean.rs
@@ -14,9 +14,10 @@ pub struct CleanWorkflow
 
 impl CleanWorkflow
 {
-    pub fn wizard(_ctx: &mut RunnerContext) -> Result<(), BeansError>
+    pub fn wizard(ctx: &mut RunnerContext) -> Result<(), BeansError>
     {
         let target_directory = helper::get_tmp_dir();
+        let staging_dir_location = ctx.get_staging_location();
 
         info!("[CleanWorkflow] Cleaning up {}", target_directory);
         if !helper::file_exists(target_directory.clone())
@@ -46,6 +47,24 @@ impl CleanWorkflow
             });
         }
 
+         // clean up butler files if it was interrupted in previous install
+        if !helper::file_exists(staging_dir_location.clone())
+        {
+             debug!("[CleanWorkflow] Staging directory used by butler not found, nothing to clean.")
+        } else {
+            // delete temp butler directory and it's contents (and error handling)
+            info!("[CleanWorkflow] Cleaning up {}", staging_dir_location);
+            if let Err(e) = std::fs::remove_dir_all(&staging_dir_location)
+            {
+                debug!("[CleanWorkflow::wizard] remove_dir_all {:#?}", e);
+                return Err(BeansError::CleanTempFailure {
+                    location: staging_dir_location,
+                    error: e,
+                    backtrace: std::backtrace::Backtrace::capture()
+                });
+            }
+        }
+        
         info!("[CleanWorkflow] Done!");
         Ok(())
     }


### PR DESCRIPTION
If the `butler-staging` directory is detected in the `sourcemods` directory, the clean up command will remove it.

Otherwise it silently reports the folder isn't there.