### PR TITLE
feat: Display program information when program runs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ fltk = { version = "1.5.21" }
 fltk-theme = "0.7.9"
 dark-light = "2.0.0"
 image = { version = "0.25.8", features = ["png"] }
+current_platform = "0.2.0"
 
 [build-dependencies]
 fl2rust = "0.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Open-Source Installer for Sourcemods"
 repository = "https://github.com/ktwrd/beans-rs"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 
 [dependencies]
 async-recursion = "1.1.1"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -631,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    bean-rs is a Source Installer for Sourcemods written in Rust
+    Copyright (C) 2024  Kate Ward
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    <program>  Copyright (C) <year>  <name of author>
+    beans-rs  Copyright (C) 2024  Kate Ward
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,8 +226,10 @@ impl Launcher
                 Self::create_location_arg(),
                 Self::create_confirm_arg()
             ]);
-        println!("beans-rs v{} ({}) Copyright (c) 2024 Kate Ward", beans_rs::VERSION, COMPILED_ON);
-        println!("License GPLv3-only\n");
+        println!("beans-rs v{} ({})", beans_rs::VERSION, COMPILED_ON);
+        println!("Copyright (c) 2024 Kate Ward");
+        println!("License GPLv3-only");
+        println!();
         println!("For a full list of contributors visit:");
         println!("<https://github.com/ktwrd/beans-rs/graphs/contributors>");
         println!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,7 +228,7 @@ impl Launcher
             ]);
         println!("{} v{} ({})", env!("CARGO_PKG_NAME"), beans_rs::VERSION, COMPILED_ON);
         println!("Copyright (c) 2024 Kate Ward");
-        println!("License {}-only", env!("CARGO_PKG_LICENSE"));
+        println!("License {}", env!("CARGO_PKG_LICENSE"));
         println!();
         println!("For a full list of contributors visit:");
         println!("<{}/graphs/contributors>", env!("CARGO_PKG_REPOSITORY"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,12 +226,12 @@ impl Launcher
                 Self::create_location_arg(),
                 Self::create_confirm_arg()
             ]);
-        println!("beans-rs v{} ({})", beans_rs::VERSION, COMPILED_ON);
+        println!("{} v{} ({})", env!("CARGO_PKG_NAME"), beans_rs::VERSION, COMPILED_ON);
         println!("Copyright (c) 2024 Kate Ward");
-        println!("License GPLv3-only");
+        println!("License {}-only", env!("CARGO_PKG_LICENSE"));
         println!();
         println!("For a full list of contributors visit:");
-        println!("<https://github.com/ktwrd/beans-rs/graphs/contributors>");
+        println!("<{}/graphs/contributors>", env!("CARGO_PKG_REPOSITORY"));
         println!();
         
         let mut i = Self::new(&cmd.get_matches());

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,7 +226,19 @@ impl Launcher
                 Self::create_location_arg(),
                 Self::create_confirm_arg()
             ]);
-
+        print!("beans-rs v{} ", beans_rs::VERSION );
+        #[cfg(not(target_os = "windows"))] {
+            print!("(x86_64 Linux) ");
+        }
+        #[cfg(target_os = "windows")] {
+            print!("(x86_64 Windows) ");
+        }
+        println!("Copyright (c) 2024 Kate Ward");
+        println!("License GPLv3-only\n");
+        println!("For a full list of contributors visit:");
+        println!("<https://github.com/ktwrd/beans-rs/graphs/contributors>");
+        println!();
+        
         let mut i = Self::new(&cmd.get_matches());
         if let Ok(Some(v)) = helper::beans_has_update().await
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-
+use current_platform::COMPILED_ON;
 use beans_rs::{BeansError,
                PANIC_MSG_CONTENT,
                RunnerContext,
@@ -226,14 +226,7 @@ impl Launcher
                 Self::create_location_arg(),
                 Self::create_confirm_arg()
             ]);
-        print!("beans-rs v{} ", beans_rs::VERSION );
-        #[cfg(not(target_os = "windows"))] {
-            print!("(x86_64 Linux) ");
-        }
-        #[cfg(target_os = "windows")] {
-            print!("(x86_64 Windows) ");
-        }
-        println!("Copyright (c) 2024 Kate Ward");
+        println!("beans-rs v{} ({}) Copyright (c) 2024 Kate Ward", beans_rs::VERSION, COMPILED_ON);
         println!("License GPLv3-only\n");
         println!("For a full list of contributors visit:");
         println!("<https://github.com/ktwrd/beans-rs/graphs/contributors>");

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -123,10 +123,10 @@ impl WizardContext
                         "======== A new update for {} is available! (latest: v{}, current: v{}) ========",
                         av.mod_info.name_stylized, rv, cv
                     );
+                    println!();
                 }
             }
         }
-        println!();
         println!("1 - Install or reinstall the game");
         println!("2 - Check for and apply any available updates");
         println!("3 - Verify and repair game files");


### PR DESCRIPTION
- Added missing copyright information to License
- Added `current_platform` crate to identify compiled platform
- Display program name, version, platform, copyright notice, license and contributors list on program start