### PR TITLE
Update to latest version of nightly & update packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,10 @@ features = [
     "release-health",
     
     "reqwest",
-    "rustls"
+    "rustls",
+
+    "logs",
+    "log"
 ]
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ fn main()
         max_breadcrumbs: 100,
         auto_session_tracking: true,
         attach_stacktrace: true,
+        enable_logs: true,
         ..Default::default()
     }));
     init_panic_handle();


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on #66 

Logging is already implemented for Sentry, but it's not enabled. This PR just enables the option when initialising the Sentry SDK so crash logs are actually submitted (which my glitchtip instance now supports, yay!)