### PR TITLE
Improve reqwest usage & errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ colored = "3.0.0"
 sentry-log = "0.45.0"
 chrono = "0.4.42"
 
-fltk = { version = "1.5.21" }
+fltk = { version = "1.5.21", features = ["fltk-bundled"] }
 fltk-theme = "0.7.9"
 dark-light = "2.0.0"
 image = { version = "0.25.8", features = ["png"] }

--- a/src/appvar.rs
+++ b/src/appvar.rs
@@ -1,4 +1,5 @@
-use std::sync::RwLock;
+use std::{backtrace::Backtrace,
+          sync::RwLock};
 
 use lazy_static::lazy_static;
 use log::{debug,
@@ -33,17 +34,33 @@ impl AppVarData
     pub fn parse() -> Self
     {
         debug!("[AppVarData::parse] trying to get JSON_DATA");
-        let x = JSON_DATA.read();
-        if let Ok(data) = x
+        match JSON_DATA.read()
         {
-            debug!("[AppVarData::parse] JSON_DATA= {:#?}", data);
-            return serde_json::from_str(&data).expect("Failed to deserialize JSON_DATA");
+            Ok(data) =>
+            {
+                debug!("[AppVarData::parse] JSON_DATA= {:#?}", data);
+                match serde_json::from_str(&data)
+                {
+                    Ok(v) => v,
+                    Err(e) =>
+                    {
+                        let error = BeansError::SerdeJson {
+                            content: Some(format!("{data}")),
+                            error: e,
+                            backtrace: Backtrace::capture()
+                        };
+                        panic!(
+                            "Failed to deserialize embedded appvar.json!!!\n{:#?}",
+                            error
+                        );
+                    }
+                }
+            }
+            Err(e) =>
+            {
+                panic!("[AppVarData::parse] Failed to read JSON_DATA {:#?}", e);
+            }
         }
-        if let Err(e) = x
-        {
-            panic!("[AppVarData::parse] Failed to read JSON_DATA {:#?}", e);
-        }
-        unreachable!();
     }
 
     /// Substitute values in the `source` string for what is defined in here.

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,16 +62,18 @@ pub enum BeansError
         error: std::io::Error,
         backtrace: Backtrace
     },
-    #[error("Failed to send request ({error:})")]
+    #[error("Failed to send request: {error_message:} ({error:})")]
     Reqwest
     {
+        error_message: String,
         error: reqwest::Error,
         backtrace: Backtrace
     },
-    #[error("Failed to serialize or deserialize data ({error:})")]
+    #[error("Failed to serialize or deserialize data ({error:})\n{content:?}")]
     SerdeJson
     {
         error: serde_json::Error,
+        content: Option<String>,
         backtrace: Backtrace
     },
 
@@ -448,6 +450,7 @@ impl From<reqwest::Error> for BeansError
     fn from(e: reqwest::Error) -> Self
     {
         BeansError::Reqwest {
+            error_message: String::from("Failed to process request"),
             error: e,
             backtrace: Backtrace::capture()
         }
@@ -459,6 +462,7 @@ impl From<serde_json::Error> for BeansError
     {
         BeansError::SerdeJson {
             error: e,
+            content: None,
             backtrace: Backtrace::capture()
         }
     }

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -776,9 +776,10 @@ pub fn get_tmp_file(filename: String) -> String
 /// the current release.
 pub async fn beans_has_update() -> Result<Option<GithubReleaseItem>, BeansError>
 {
+    let user_agent = crate::get_user_agent();
     let rs = reqwest::Client::new()
         .get(GITHUB_RELEASES_URL)
-        .header(USER_AGENT, &format!("beans-rs/{}", crate::VERSION))
+        .header(USER_AGENT, &user_agent)
         .send()
         .await;
     let response = match rs
@@ -786,11 +787,15 @@ pub async fn beans_has_update() -> Result<Option<GithubReleaseItem>, BeansError>
         Ok(v) => v,
         Err(e) =>
         {
-            trace!("Failed get latest release from github \nerror: {:#?}", e);
-            return Err(BeansError::Reqwest {
+            let message =
+                format!("Failed to get latest release from github: {GITHUB_RELEASES_URL:}");
+            let err = BeansError::Reqwest {
+                error_message: message,
                 error: e,
                 backtrace: Backtrace::capture()
-            });
+            };
+            trace!("[helper::beans_has_update] {:#?}", err);
+            return Err(err);
         }
     };
     let response_text = response.text().await?;
@@ -799,17 +804,18 @@ pub async fn beans_has_update() -> Result<Option<GithubReleaseItem>, BeansError>
         Ok(v) => v,
         Err(e) =>
         {
-            trace!(
-                "Failed to deserialize GithubReleaseItem\nerror: {:#?}\ncontent: {:#?}",
-                e, response_text
-            );
-            return Err(BeansError::SerdeJson {
+            let error = BeansError::SerdeJson {
                 error: e,
+                content: Some(response_text),
                 backtrace: Backtrace::capture()
-            });
+            };
+            trace!(
+                "[beans_rs::beans_has_update] Failed to deserialize GithubReleaseItem from URL {GITHUB_RELEASES_URL:}\n{error:#?}"
+            );
+            return Err(error);
         }
     };
-    trace!("{:#?}", data);
+    trace!("[beans_rs::beans_has_update] response data from URL {GITHUB_RELEASES_URL:}\n{data:#?}");
     if !data.draft && !data.prerelease && data.tag_name != format!("v{}", crate::VERSION)
     {
         return Ok(Some(data.clone()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,9 +217,8 @@ pub fn has_gui_support() -> bool
 /// User agent for downloading files or sending web requests.
 pub fn get_user_agent() -> String
 {
-    let mut result = String::from("beans-rs/");
-    result.push_str(&VERSION);
-    result
+    let av = crate::AppVarData::get();
+    format!("beans-rs/{:} ({:})", VERSION, av.mod_info.sourcemod_name)
 }
 
 pub fn staging_dir() -> String

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use current_platform::COMPILED_ON;
+
 use beans_rs::{BeansError,
                PANIC_MSG_CONTENT,
                RunnerContext,
@@ -19,6 +19,7 @@ use clap::{Arg,
            ArgAction,
            ArgMatches,
            Command};
+use current_platform::COMPILED_ON;
 use log::{LevelFilter,
           debug,
           error,
@@ -226,14 +227,19 @@ impl Launcher
                 Self::create_location_arg(),
                 Self::create_confirm_arg()
             ]);
-        println!("{} v{} ({})", env!("CARGO_PKG_NAME"), beans_rs::VERSION, COMPILED_ON);
+        println!(
+            "{} v{} ({})",
+            env!("CARGO_PKG_NAME"),
+            beans_rs::VERSION,
+            COMPILED_ON
+        );
         println!("Copyright (c) 2024 Kate Ward");
         println!("License {}", env!("CARGO_PKG_LICENSE"));
         println!();
         println!("For a full list of contributors visit:");
         println!("<{}/graphs/contributors>", env!("CARGO_PKG_REPOSITORY"));
         println!();
-        
+
         let mut i = Self::new(&cmd.get_matches());
         if let Ok(Some(v)) = helper::beans_has_update().await
         {

--- a/src/version.rs
+++ b/src/version.rs
@@ -32,10 +32,17 @@ pub fn get_current_version(sourcemods_location: Option<String>) -> Option<usize>
             let location = format!("{}.adastral", smp_x);
             let content =
                 read_to_string(&location).unwrap_or_else(|_| panic!("Failed to open {}", location));
-            let data: AdastralVersionFile = serde_json::from_str(&content)
-                .unwrap_or_else(|_| panic!("Failed to deserialize data at {}", location));
+            let data: AdastralVersionFile = serde_json::from_str(&content).unwrap_or_else(|_| {
+                panic!(
+                    "Failed to deserialize data at \"{:}\" with content:\n{:#?}",
+                    location, content
+                )
+            });
             let parsed = data.version.parse::<usize>().unwrap_or_else(|_| {
-                panic!("Failed to convert version to usize! ({})", data.version)
+                panic!(
+                    "Failed to convert version ({}) to usize!\nLocation:{}\nContent: {}",
+                    data.version, location, content
+                );
             });
 
             Some(parsed)
@@ -268,20 +275,46 @@ pub fn update_version_file(sourcemods_location: Option<String>) -> Result<(), Be
 pub async fn get_version_list() -> Result<RemoteVersionResponse, BeansError>
 {
     let av = AppVarData::get();
-    let response = match reqwest::get(&av.remote_info.versions_url).await
+    let user_agent = crate::get_user_agent();
+    let client = match reqwest::Client::builder().user_agent(&user_agent).build()
     {
         Ok(v) => v,
         Err(e) =>
         {
-            error!(
-                "[version::get_version_list] Failed to get available versions! {:}",
-                e
+            let message = format!(
+                "Failed to create reqwest client (with user agent: {:})",
+                user_agent
             );
-            sentry::capture_error(&e);
-            return Err(BeansError::Reqwest {
+            error!("[version::get_version_list] {message:} {:}", e);
+            let error = BeansError::Reqwest {
+                error_message: message,
                 error: e,
                 backtrace: Backtrace::capture()
-            });
+            };
+            trace!("[version::get_version_list] {:#?}", error);
+            sentry::capture_error(&error);
+            return Err(error);
+        }
+    };
+
+    let response = match client.get(&av.remote_info.versions_url).send().await
+    {
+        Ok(v) => v,
+        Err(e) =>
+        {
+            let message = format!(
+                "Failed to get available versions from URL {:}",
+                av.remote_info.versions_url
+            );
+            error!("[version::get_version_list] {message} {:}", e);
+            let error = BeansError::Reqwest {
+                error_message: message,
+                error: e,
+                backtrace: Backtrace::capture()
+            };
+            trace!("[version::get_version_list] {:#?}", error);
+            sentry::capture_error(&error);
+            return Err(error);
         }
     };
     let response_text = response.text().await?;
@@ -291,7 +324,23 @@ pub async fn get_version_list() -> Result<RemoteVersionResponse, BeansError>
     );
 
     let data: RemoteVersionResponse = serde_json::from_str(&response_text)?;
-    Ok(data)
+    match serde_json::from_str(&response_text)
+    {
+        Ok(v) => Ok(v),
+        Err(e) =>
+        {
+            let error = BeansError::SerdeJson {
+                content: Some(response_text),
+                error: e,
+                backtrace: Backtrace::capture()
+            };
+            trace!(
+                "[version::get_version_list] failed to deserialize response from {:}\nerror: {:#?}",
+                av.remote_info.versions_url, error
+            );
+            Err(error)
+        }
+    }
 }
 
 /// Version file that is used as `.adastral` in the sourcemod mod folder.


### PR DESCRIPTION
This PR improves the usage of `reqwest` when fetching `versions.json` so it actually sends the user agent defined in `src/lib.rs`. This PR also improves some of the data stored in errors, so if there's a `BeansError::SerdeJson` thrown/returned, then it'll include the content it was trying to deserialise. The error `Reqwest` also now includes an error message field, so more information can be described when returning that error.

Along with this, the user agent has been updated to include the sourcemod name, so the user agent for Open Fortress would be `beans-rs/1.7.3 (open_fortress)`.